### PR TITLE
Slightly improved U.S. English translation

### DIFF
--- a/src/main/resources/assets/trashslot/lang/en_us.json
+++ b/src/main/resources/assets/trashslot/lang/en_us.json
@@ -1,8 +1,8 @@
 {
-  "trashslot.serverNotInstalled": "This server does not have TrashSlot installed. It will be disabled.",
-  "key.trashslot.toggle": "Toggle Slot",
+  "trashslot.serverNotInstalled": "The server does not have TrashSlot installed. This mod will be disabled.",
+  "key.trashslot.toggle": "Show/Hide TrashSlot",
   "key.trashslot.delete": "Delete Item",
   "key.trashslot.deleteAll": "Delete All Items of Type",
   "key.categories.trashslot": "TrashSlot",
-  "trashslot.config.instantDeletion": "Instant Deletion"
+  "trashslot.config.instantDeletion": "Instant Deleting"
 }


### PR DESCRIPTION
In this commit, as the title says, I slightly improved U.S. English translation.

I also noticed that only option name in config is translatable, but not the description.